### PR TITLE
Address issues #2 and #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This repo provides an implementation of the following incremental learning algor
 python avg.py --env "Humanoid-v4" --N 10001000
 ```
 
-![AVG](assets/AVG.gif)
+## Learned Behavior in Simulation
+<!-- ![AVG](assets/AVG.gif){width=200px height=200px} -->
 
+<img src="assets/AVG.gif" width="320" height="240" alt="Description">
 
 ## Robot Tasks
 
@@ -49,4 +51,8 @@ python hyp_sweep.py --algo "isac" --hyp_seed 146 --env "HalfCheetah-v4" --N 1000
   year={2024}
 }
 
+```
+
+```
+Vasan, Gautham, Mohamed Elsayed, Seyed Alireza Azimi, Jiamin He, Fahim Shahriar, Colin Bellinger, Martha White, and A. Rupam Mahmood (2024). "Deep Policy Gradient Methods Without Batch Updates, Target Networks, or Replay Buffers." In The Thirty-eighth Annual Conference on Neural Information Processing Systems.
 ```

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ python hyp_sweep.py --algo "isac" --hyp_seed 146 --env "HalfCheetah-v4" --N 1000
 ```
 
 ```
-Vasan, Gautham, Mohamed Elsayed, Seyed Alireza Azimi, Jiamin He, Fahim Shahriar, Colin Bellinger, Martha White, and A. Rupam Mahmood (2024). "Deep Policy Gradient Methods Without Batch Updates, Target Networks, or Replay Buffers." In The Thirty-eighth Annual Conference on Neural Information Processing Systems.
+Vasan, G., Elsayed, M., Azimi, S. A., He, J., Shahriar, F., Bellinger, C., White, M., & Mahmood, A. R. (2024). Deep Policy Gradient Methods Without Batch Updates, Target Networks, or Replay Buffers. In The Thirty-eighth Annual Conference on Neural Information Processing Systems.
 ```

--- a/avg.py
+++ b/avg.py
@@ -7,9 +7,10 @@ import gymnasium as gym
 import torch.nn.functional as F
 
 from torch.distributions import MultivariateNormal
-from gymnasium.wrappers import NormalizeObservation
+from gymnasium.wrappers import NormalizeObservation, ClipAction
 from datetime import datetime
 from incremental_rl.experiment_tracker import record_video
+from incremental_rl.td_error_scaler import TDErrorScaler
 
 
 def orthogonal_weight_init(m):
@@ -116,6 +117,8 @@ class AVG:
         self.qopt = torch.optim.Adam(self.Q.parameters(), lr=cfg.critic_lr, betas=cfg.betas)
 
         self.alpha, self.gamma, self.device = cfg.alpha_lr, cfg.gamma, cfg.device
+        self.td_error_scaler = TDErrorScaler()
+        self.G = 0
 
     def compute_action(self, obs):
         obs = torch.Tensor(obs.astype(np.float32)).unsqueeze(0).to(self.device)
@@ -127,6 +130,16 @@ class AVG:
         next_obs = torch.Tensor(next_obs.astype(np.float32)).unsqueeze(0).to(self.device)
         action, lprob = action.to(self.device), kwargs['lprob']
 
+        #### Return scaling
+        r_ent = reward - self.alpha * lprob.detach().item()
+        self.G += r_ent        
+        if done:
+            self.td_error_scaler.update(reward=r_ent, gamma=0, G=self.G)
+            self.G = 0
+        else:
+            self.td_error_scaler.update(reward=r_ent, gamma=self.cfg.gamma, G=None)
+        ####
+
         #### Q loss
         q = self.Q(obs, action.detach())    # N.B: Gradient should NOT pass through action here
         with torch.no_grad():
@@ -136,6 +149,7 @@ class AVG:
             target_V = q2 - self.alpha * next_lprob
 
         delta = reward + (1 - done) *  self.gamma * target_V - q
+        delta /= self.td_error_scaler.sigma
         qloss = delta ** 2
         ####
 
@@ -170,6 +184,7 @@ def main(args):
     env = gym.make(args.env)
     env = gym.wrappers.FlattenObservation(env)
     env = NormalizeObservation(env)
+    env = ClipAction(env)
 
     #### Reproducibility
     env.reset(seed=args.seed)

--- a/avg.py
+++ b/avg.py
@@ -1,4 +1,4 @@
-import torch, time
+import torch, time, pickle
 import argparse, os, traceback
 
 import numpy as np
@@ -247,7 +247,6 @@ def main(args):
     if args.save_model:
         agent.save(model_dir=args.results_dir, unique_str=f"{run_id}_model")
 
-
     print("Run with id: {} took {:.3f}s!".format(run_id, time.time()-tic))
     
     # Eval
@@ -293,4 +292,15 @@ if __name__ == "__main__":
     
     # Start experiment
     set_one_thread()
-    main(args)
+    ep_steps, rets = main(args)
+
+    # Save hyper-parameters and config info
+    hyperparams_dict = vars(args)
+    hyperparams_dict["device"] = str(hyperparams_dict["device"])
+    pkl_data = {'args': hyperparams_dict}
+
+    ### Saving data
+    os.makedirs(args.results_dir, exist_ok=True)
+    pkl_fpath = os.path.join(args.results_dir, "./{}_avg_default_seed-{}.pkl".format(args.env, args.seed))
+    with open(pkl_fpath, "wb") as f:
+        pickle.dump((ep_steps, rets, args.env), f)

--- a/incremental_rl/avg_ablation.py
+++ b/incremental_rl/avg_ablation.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 from torch.distributions import MultivariateNormal
 from incremental_rl.logger import Logger
 from incremental_rl.td_error_scaler import TDErrorScaler
-from gymnasium.wrappers import NormalizeObservation
+from gymnasium.wrappers import NormalizeObservation, ClipAction
 from incremental_rl.utils import orthogonal_weight_init, human_format_numbers, set_one_thread
 from incremental_rl.experiment_tracker import ExperimentTracker, record_video
 
@@ -209,6 +209,7 @@ def main(args):
     env = gym.wrappers.FlattenObservation(env)
     if args.normalize_obs:
         env = NormalizeObservation(env)
+    env = ClipAction(env)
 
     #### Reproducibility
     env.reset(seed=args.seed)

--- a/incremental_rl/norm_incremental_actor_critic.py
+++ b/incremental_rl/norm_incremental_actor_critic.py
@@ -11,7 +11,7 @@ from torch.distributions import MultivariateNormal
 from torch.optim import Adam
 from incremental_rl.logger import Logger
 from incremental_rl.td_error_scaler import TDErrorScaler
-from gymnasium.wrappers import NormalizeObservation
+from gymnasium.wrappers import NormalizeObservation, ClipAction
 from incremental_rl.utils import orthogonal_weight_init, set_one_thread
 from incremental_rl.experiment_tracker import ExperimentTracker
 
@@ -208,6 +208,7 @@ def main(args):
     env = gym.wrappers.FlattenObservation(env)
     if args.normalize_obs:
         env = NormalizeObservation(env)
+    env = ClipAction(env)
 
     #### Reproducibility
     env.reset(seed=args.seed)

--- a/incremental_rl/norm_isac.py
+++ b/incremental_rl/norm_isac.py
@@ -8,7 +8,7 @@ import gymnasium as gym
 import torch.nn.functional as F
 
 from torch.distributions import MultivariateNormal
-from gymnasium.wrappers import NormalizeObservation
+from gymnasium.wrappers import NormalizeObservation, ClipAction
 from copy import deepcopy
 from incremental_rl.logger import Logger
 from incremental_rl.td_error_scaler import TDErrorScaler
@@ -279,6 +279,7 @@ def main(args):
     env = gym.wrappers.FlattenObservation(env)
     if args.normalize_obs:
         env = NormalizeObservation(env)
+    env = ClipAction(env)
 
     #### Reproducibility
     env.reset(seed=args.seed)


### PR DESCRIPTION
- [x]  In #2, @JagerHoHo highlighted that `avg.py` does not use the `TDErrorScaler` in its implementation. This is included here
- [x] In #3, @SakodaShintaro pointed out that we do not clip or rescale actions appropriately for environments such as `Humanoid-v4`. To address this, we use the ClipAction wrapper from Gymnasium to enforce proper action bounds. Note that this does not apply any affine transforms for scaling actions. We trust the agent designers to model action spaces appropriately and only perform clipping.
